### PR TITLE
Add Color Mode and Fix Readme Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Pickled (i.e., serialized) todo list objects are saved in ~/.local/share/py-todo
 ## Installation
 * Arch Linux - [AUR](https://aur.archlinux.org/packages/py-todo) (Submitted by [RewoundVHS](https://github.com/RewoundVHS))
 ```
-yaourt -S py-todo
+yay -S py-todo
 ```
 
 * Manual Installation (Linux)
@@ -41,13 +41,13 @@ $ cd py-todo && cp todo /usr/local/bin/
 
 ## Usage
 ```
-$ todo                               # List all items.
-$ todo -a                            # Add an item. (with Title / Expiry Date prompt)
-$ todo -a <title> <expiry_date>      # Add an item. (without Title / Expiry Date prompt)
-$ todo -r <indices>                  # Remove one or more items.
-$ todo -h                            # Display help message.
-$ todo -v                            # Display version info.
-$ todo -org <filename>               # Adds TODOs from Emacs org mode
+$ todo								# List all items.
+$ todo -a							# Add an item. (with Title / Expiry Date prompt)
+$ todo -a <title> <expiry_date>		# Add an item. (without Title / Expiry Date prompt)
+$ todo -r <indices>					# Remove one or more items.
+$ todo -h							# Display help message.
+$ todo -v							# Display version info.
+$ todo -org <filename>				# Adds TODOs from Emacs org mode
 ```
 
 ## Configuration
@@ -55,6 +55,7 @@ This part is totally optional. Edit ~/.config/py-todo/config:
 ```
 detail_mode = true / false
 week_start_day = Sun / Mon
+color = true / false
 ```
 
 With **detail_mode** set to **true**:

--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ $ cd py-todo && cp todo /usr/local/bin/
 
 ## Usage
 ```
-$ todo								# List all items.
-$ todo -a							# Add an item. (with Title / Expiry Date prompt)
-$ todo -a <title> <expiry_date>		# Add an item. (without Title / Expiry Date prompt)
-$ todo -r <indices>					# Remove one or more items.
-$ todo -h							# Display help message.
-$ todo -v							# Display version info.
-$ todo -org <filename>				# Adds TODOs from Emacs org mode
+$ todo                                   # List all items.
+$ todo -a                                # Add an item. (with Title / Expiry Date prompt)
+$ todo -a <title> <expiry_date>          # Add an item. (without Title / Expiry Date prompt)
+$ todo -e <index>                        # Edits an item. (with Title / Expiry Date prompt)
+$ todo -e <index> <titls> <expiry_date>  # Edits an item. (without Title / Expiry Date prompt)
+$ todo -r <indices>                      # Remove one or more items.
+$ todo -h                                # Display help message.
+$ todo -v                                # Display version info.
+$ todo -org <filename>                  # Adds TODOs from Emacs org mode
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ todo -e <index> <titls> <expiry_date>  # Edits an item. (without Title / Expir
 $ todo -r <indices>                      # Remove one or more items.
 $ todo -h                                # Display help message.
 $ todo -v                                # Display version info.
-$ todo -org <filename>                  # Adds TODOs from Emacs org mode
+$ todo -org <filename>                     # Adds TODOs from Emacs org mode
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ todo -org <filename>               # Adds TODOs from Emacs org mode
 ```
 
 ## Configuration
-User configuration is totally optional. Edit ~/.config/py-todo/config:
+This part is totally optional. Edit ~/.config/py-todo/config:
 ```
 detail_mode = true / false
 week_start_day = Sun / Mon

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ todo -e <index> <titls> <expiry_date>  # Edits an item. (without Title / Expir
 $ todo -r <indices>                      # Remove one or more items.
 $ todo -h                                # Display help message.
 $ todo -v                                # Display version info.
-$ todo -org <filename>                     # Adds TODOs from Emacs org mode
+$ todo -org <filename>                    # Adds TODOs from Emacs org mode
 ```
 
 ## Configuration

--- a/todo
+++ b/todo
@@ -100,6 +100,7 @@ def print_usage():
     print("Configuration Options (See " + config_location + config_name + "):")
     print("* detail_mode = true / false")
     print("* week_start_day = Sun / Mon")
+    print("* color = true / false")
 
 
 def print_version():

--- a/todo
+++ b/todo
@@ -14,7 +14,8 @@ config_location = str(Path.home()) + '/.config/py-todo/'
 config_name = 'config'
 config = {
     'detail_mode': 'false',
-    'week_start_day': 'Sun'
+    'week_start_day': 'Sun',
+    'color': 'false'
 }
 
 datafile_location = str(Path.home()) + '/.local/share/py-todo/'
@@ -68,12 +69,19 @@ def remove_item(indices: list):
 
 
 def list_items():
+    color5 = '\x1b[0;34;40m{}\x1b[0m'
+    color3 = '\x1b[0;32;40m{}\x1b[0m'
     if len(items) > 0:
         print("You have {item_count} item{s} left on the reminder!".format(
             item_count=len(items), s="s" if len(items) >= 2 else ""))
         index = 0
         for item in items:
-            print(str(index) + ") " + item.__str__())
+            if 'color' in config and config['color'] in ['true', 'True']:
+                task = item.__str__().split('(')[0]
+                date = '(' + item.__str__().split('(')[1]
+                print(color5.format(str(index) + ") ") + task + color3.format(date))
+            else:
+                print(str(index) + ") " + item.__str__())
             index += 1
 
 


### PR DESCRIPTION
## Color Mode

I added a color mode that can be activated by adding the following to the config file

`color = true`

Here is a screenshot of color mode in action

![2018-10-26-214621_1600x900_scrot](https://user-images.githubusercontent.com/23706925/47598520-b3bbf300-d96a-11e8-8248-b78fba6ec2d1.png)

## Readme

I also changed the README a little bit. `yaourt` is unsupported and `yay` is a much more optimal AUR helper. Also the last element on the list of help items was misaligned so I fixed that.